### PR TITLE
SEO audit fixes and homepage improvements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: '${{ github.token }}'
+          fetch-depth: 0
       - name: Build storageclass.info
         run: |
           sudo apt install -y npm

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,7 +1,7 @@
 <IfModule mod_rewrite.c>
 RewriteEngine On
 Redirect 301 "/csidrivers" "/drivers"
-RewriteBase /subdirectory
+RewriteBase /
 RewriteRule ^index\.html$ - [L]
 
 RewriteRule glossary/?$ /index.html [L]

--- a/public/glossary/csi-driver.md
+++ b/public/glossary/csi-driver.md
@@ -1,6 +1,12 @@
 ---
 title: CSI Driver Basics and Key Concepts Explained
 description: CSI Driver simplifies container storage in Kubernetes and is a key tool for managing dynamic volumes in DevOps workflows.
+keywords:
+  - CSI driver
+  - Kubernetes CSI
+  - container storage interface
+  - storage driver
+  - Kubernetes storage
 ---
 
 # What is a CSI Driver?

--- a/public/glossary/csi-volume-cloning.md
+++ b/public/glossary/csi-volume-cloning.md
@@ -1,6 +1,12 @@
 ---
 title: How CSI Volume Cloning Works in Storage
 description: CSI Volume Cloning allows fast duplication of volumes in Kubernetes using the CSI spec and simplifies persistent storage workflows.
+keywords:
+  - CSI volume cloning
+  - Kubernetes volume clone
+  - CSI clone
+  - persistent volume clone
+  - Kubernetes storage
 ---
 
 # What is CSI Volume Cloning?

--- a/public/glossary/dynamic-provisioning-in-kubernetes.md
+++ b/public/glossary/dynamic-provisioning-in-kubernetes.md
@@ -1,6 +1,12 @@
 ---
 title: Understanding Dynamic Provisioning in Kubernetes
 description: Dynamic Provisioning in Kubernetes automates storage allocation for pods, improving efficiency and reducing manual steps.
+keywords:
+  - dynamic provisioning Kubernetes
+  - Kubernetes storage provisioning
+  - CSI dynamic provisioning
+  - StorageClass provisioning
+  - Kubernetes persistent volume
 ---
 
 # What is Dynamic Provisioning in Kubernetes?

--- a/public/glossary/ext4.md
+++ b/public/glossary/ext4.md
@@ -1,6 +1,12 @@
 ---
 title: ext4 File System Overview and Features
 description: ext4 is a journaling file system used in Linux that offers improved performance, reliability, and support for large files.
+keywords:
+  - ext4 file system
+  - Linux ext4
+  - ext4 Kubernetes
+  - journaling file system
+  - Linux file system
 ---
 
 # What is ext4?

--- a/public/glossary/glusterfs.md
+++ b/public/glossary/glusterfs.md
@@ -1,6 +1,12 @@
 ---
 title: How GlusterFS Handles Distributed Storage
 description: Learn how GlusterFS enables distributed file storage across multiple servers with flexibility and redundancy.
+keywords:
+  - GlusterFS
+  - distributed file storage
+  - GlusterFS Kubernetes
+  - network file storage
+  - open source storage
 ---
 
 # What is GlusterFS?

--- a/public/glossary/helm-chart.md
+++ b/public/glossary/helm-chart.md
@@ -1,6 +1,12 @@
 ---
 title: What a Helm Chart Does in Kubernetes
 description: Helm Chart simplifies deployment and scaling in Kubernetes by packaging app resources into manageable templates.
+keywords:
+  - Helm chart
+  - Kubernetes Helm
+  - Helm deployment
+  - Kubernetes package manager
+  - Helm templates
 ---
 # What is Helm Chart?
 

--- a/public/glossary/iscsi.md
+++ b/public/glossary/iscsi.md
@@ -1,6 +1,12 @@
 ---
 title: Benefits of Using iSCSI in Storage
 description: iSCSI is a storage protocol used to link data storage across networks, often used in virtual and cloud-based infrastructures.
+keywords:
+  - iSCSI
+  - iSCSI storage
+  - iSCSI Kubernetes
+  - block storage protocol
+  - SAN storage
 ---
 
 # What is iSCSI?

--- a/public/glossary/kubernetes-block-storage.md
+++ b/public/glossary/kubernetes-block-storage.md
@@ -1,6 +1,12 @@
 ---
 title: How Kubernetes Block Storage Works
 description: Understand Kubernetes Block Storage and its role in managing persistent, high-performance volumes for critical applications.
+keywords:
+  - Kubernetes block storage
+  - Kubernetes persistent block volume
+  - CSI block storage
+  - block device Kubernetes
+  - Kubernetes storage
 ---
 # What is Kubernetes Block Storage?
 

--- a/public/glossary/kubernetes-csi-architecture.md
+++ b/public/glossary/kubernetes-csi-architecture.md
@@ -1,6 +1,12 @@
 ---
 title: Kubernetes CSI Architecture for Scalability
 description: Kubernetes CSI Architecture enables fast, cloud-agnostic storage operations via modular drivers and decoupled control flows.
+keywords:
+  - Kubernetes CSI architecture
+  - CSI plugin architecture
+  - container storage interface architecture
+  - CSI sidecar
+  - Kubernetes storage driver
 ---
 
 # What is Kubernetes CSI Architecture?

--- a/public/glossary/kubernetes-csi-migration.md
+++ b/public/glossary/kubernetes-csi-migration.md
@@ -1,6 +1,12 @@
 ---
 title: Kubernetes CSI Migration for In-Tree Plugins
 description: Kubernetes CSI Migration moves in-tree storage plugins to external CSI drivers, improving modularity and maintainability.
+keywords:
+  - Kubernetes CSI migration
+  - in-tree plugin migration
+  - CSI migration
+  - Kubernetes storage migration
+  - storage plugin migration
 ---
 # What is Kubernetes CSI Migration?
 

--- a/public/glossary/kubernetes-csi-provisioner.md
+++ b/public/glossary/kubernetes-csi-provisioner.md
@@ -1,6 +1,12 @@
 ---
 title: Key Functions of Kubernetes CSI Provisioner
 description: Kubernetes CSI Provisioner is a sidecar container that enables dynamic provisioning using CSI-compliant storage backends.
+keywords:
+  - Kubernetes CSI provisioner
+  - CSI external provisioner
+  - dynamic provisioning sidecar
+  - CSI sidecar container
+  - Kubernetes storage provisioner
 ---
 # What is Kubernetes CSI Provisioner?
 

--- a/public/glossary/kubernetes-csi-raw-device.md
+++ b/public/glossary/kubernetes-csi-raw-device.md
@@ -1,6 +1,12 @@
 ---
 title: Understanding Kubernetes CSI Raw Device Mode
 description: Kubernetes CSI Raw Device enables pods to mount storage volumes as raw block devices for performance-sensitive workloads.
+keywords:
+  - Kubernetes CSI raw device
+  - raw block volume Kubernetes
+  - block device mode CSI
+  - Kubernetes raw block
+  - CSI volumeMode
 ---
 # What is Kubernetes CSI Raw Device?
 

--- a/public/glossary/kubernetes-csi-resizer.md
+++ b/public/glossary/kubernetes-csi-resizer.md
@@ -1,6 +1,12 @@
 ---
 title: How Kubernetes CSI Resizer Expands Volumes
 description: Kubernetes CSI Resizer works with volumeMode File and Block to scale storage transparently in running Kubernetes workloads.
+keywords:
+  - Kubernetes CSI resizer
+  - volume expansion CSI
+  - CSI external resizer
+  - Kubernetes volume resize
+  - PVC resize
 ---
 # What is Kubernetes CSI Resizer?
 

--- a/public/glossary/kubernetes-csi-snapshotter.md
+++ b/public/glossary/kubernetes-csi-snapshotter.md
@@ -1,6 +1,12 @@
 ---
 title: Kubernetes CSI Snapshotter for Volume Recovery
 description: Learn how Kubernetes CSI Snapshotter handles backup-ready volume snapshots in Kubernetes through external controllers.
+keywords:
+  - Kubernetes CSI snapshotter
+  - volume snapshot Kubernetes
+  - CSI snapshot
+  - Kubernetes backup snapshot
+  - VolumeSnapshot
 ---
 # What is Kubernetes CSI Snapshotter?
 

--- a/public/glossary/kubernetes-csi-specification.md
+++ b/public/glossary/kubernetes-csi-specification.md
@@ -1,6 +1,12 @@
 ---
 title: Kubernetes CSI Specification Core Concepts
 description: Kubernetes CSI Specification ensures consistent storage behavior across CSI drivers by enforcing implementation of core RPCs.
+keywords:
+  - Kubernetes CSI specification
+  - CSI spec
+  - container storage interface spec
+  - CSI RPC
+  - CSI standard
 ---
 # What is Kubernetes CSI Specification?
 

--- a/public/glossary/kubernetes-csi.md
+++ b/public/glossary/kubernetes-csi.md
@@ -1,6 +1,12 @@
 ---
 title: How Kubernetes CSI Improves Storage
 description: Kubernetes CSI provides a consistent framework for handling volume lifecycle across cloud, on-prem, and hybrid deployment.
+keywords:
+  - Kubernetes CSI
+  - container storage interface
+  - Kubernetes storage driver
+  - CSI plugin
+  - Kubernetes volume
 ---
 # What is Kubernetes CSI?
 

--- a/public/glossary/kubernetes-ephemeral-storage.md
+++ b/public/glossary/kubernetes-ephemeral-storage.md
@@ -1,6 +1,12 @@
 ---
 title: How Kubernetes Ephemeral Storage Works
 description: Kubernetes Ephemeral Storage supports short-lived data for pods, ideal for caches, buffers, and temporary build artifacts.
+keywords:
+  - Kubernetes ephemeral storage
+  - emptyDir Kubernetes
+  - temporary pod storage
+  - Kubernetes cache storage
+  - ephemeral volume
 ---
 # What is Kubernetes Ephemeral Storage?
 

--- a/public/glossary/kubernetes-file-storage.md
+++ b/public/glossary/kubernetes-file-storage.md
@@ -1,6 +1,12 @@
 ---
 title: Kubernetes File Storage Overview
 description: Kubernetes File Storage provides shared, mountable file systems across pods using NFS, CSI drivers, or cloud-native file volumes.
+keywords:
+  - Kubernetes file storage
+  - NFS Kubernetes
+  - shared file storage Kubernetes
+  - ReadWriteMany storage
+  - Kubernetes NFS volume
 ---
 
 # What is Kubernetes File Storage?

--- a/public/glossary/kubernetes-hostpath.md
+++ b/public/glossary/kubernetes-hostpath.md
@@ -1,6 +1,12 @@
 ---
 title: When to Use Kubernetes HostPath in Pods
 description: Kubernetes HostPath allows pods to access node-level file paths, offering flexibility with tradeoffs in security and portability.
+keywords:
+  - Kubernetes HostPath
+  - hostPath volume
+  - Kubernetes node storage
+  - pod host filesystem
+  - Kubernetes local volume
 ---
 
 # What is Kubernetes HostPath?

--- a/public/glossary/kubernetes-local-storage.md
+++ b/public/glossary/kubernetes-local-storage.md
@@ -1,6 +1,12 @@
 ---
 title: Simple Guide to Kubernetes Local Storage
 description: Kubernetes Local Storage is ideal for apps requiring fast disk I/O and persistent data on specific nodes in the cluster.
+keywords:
+  - Kubernetes local storage
+  - local persistent volume
+  - Kubernetes node-local storage
+  - local volume provisioner
+  - Kubernetes disk
 ---
 
 # What is Kubernetes Local Storage?

--- a/public/glossary/kubernetes-object-storage.md
+++ b/public/glossary/kubernetes-object-storage.md
@@ -1,6 +1,12 @@
 ---
 title: What Is Kubernetes Object Storage
 description: Kubernetes Object Storage lets apps store unstructured data like images and logs using S3-compatible or cloud-native backends.
+keywords:
+  - Kubernetes object storage
+  - S3 Kubernetes
+  - object storage CSI
+  - Kubernetes blob storage
+  - cloud object storage
 ---
 # What is Kubernetes Object Storage?
 

--- a/public/glossary/kubernetes-persistent-storage-on-windows.md
+++ b/public/glossary/kubernetes-persistent-storage-on-windows.md
@@ -1,6 +1,12 @@
 ---
-title: What Is Kubernetes Persistent Storage on Windows 
+title: What Is Kubernetes Persistent Storage on Windows
 description: Kubernetes Persistent Storage on Windows supports StatefulSets and PVCs using compatible storage backends like SMB or CSI driver.
+keywords:
+  - Kubernetes persistent storage Windows
+  - Windows Kubernetes storage
+  - SMB CSI driver
+  - Windows container storage
+  - Kubernetes Windows volume
 ---
 # What is Kubernetes Persistent Storage on Windows?
 

--- a/public/glossary/kubernetes-persistent-storage.md
+++ b/public/glossary/kubernetes-persistent-storage.md
@@ -1,6 +1,12 @@
 ---
 title: What Is Kubernetes Persistent Storage
 description: Kubernetes Persistent Storage supports volume retention and dynamic provisioning for long-term pod data storage in clusters.
+keywords:
+  - Kubernetes persistent storage
+  - PersistentVolume
+  - PVC Kubernetes
+  - Kubernetes data persistence
+  - durable storage Kubernetes
 ---
 # What is Kubernetes Persistent Storage?
 

--- a/public/glossary/kubernetes-remote-storage.md
+++ b/public/glossary/kubernetes-remote-storage.md
@@ -1,6 +1,12 @@
 ---
 title: What Is Kubernetes Remote Storage
 description: Kubernetes Remote Storage helps teams share data between pods and clusters using external storage like NFS or object stores.
+keywords:
+  - Kubernetes remote storage
+  - network-attached storage Kubernetes
+  - NFS Kubernetes
+  - remote volume Kubernetes
+  - Kubernetes shared storage
 ---
 # What is Kubernetes Remote Storage?
 

--- a/public/glossary/kubernetes-storage-options.md
+++ b/public/glossary/kubernetes-storage-options.md
@@ -1,6 +1,12 @@
 ---
 title: What are Kubernetes Storage Options
 description: Kubernetes Storage Options include block, file, and object storage types, supported through CSI plugins and built-in volume drivers.
+keywords:
+  - Kubernetes storage options
+  - Kubernetes storage types
+  - block file object storage Kubernetes
+  - CSI plugins
+  - Kubernetes volume types
 ---
 # What are Kubernetes Storage Options?
 

--- a/public/glossary/kubernetes-storage.md
+++ b/public/glossary/kubernetes-storage.md
@@ -1,6 +1,12 @@
 ---
 title: What is Kubernetes Storage
 description: Kubernetes Storage supports dynamic provisioning and durable volume management using PVCs and CSI-compatible storage drivers.
+keywords:
+  - Kubernetes storage
+  - Kubernetes volumes
+  - persistent volume Kubernetes
+  - CSI Kubernetes
+  - Kubernetes data storage
 ---
 
 # What is Kubernetes Storage?

--- a/public/glossary/kubernetes-volume-expansion.md
+++ b/public/glossary/kubernetes-volume-expansion.md
@@ -1,6 +1,12 @@
 ---
 title: What is Kubernetes Volume Expansion
 description: Kubernetes Volume Expansion allows resizing of PersistentVolumes using PVC updates and supported CSI or in-tree drivers.
+keywords:
+  - Kubernetes volume expansion
+  - PVC resize Kubernetes
+  - expand PersistentVolume
+  - CSI volume resize
+  - Kubernetes storage resize
 ---
 # What is Kubernetes Volume Expansion?
 

--- a/public/glossary/logical-volume.md
+++ b/public/glossary/logical-volume.md
@@ -1,6 +1,12 @@
 ---
 title: What is Logical Volume
 description: Logical Volume lets you resize, create, and manage disk partitions easily on Linux using the Logical Volume Manager tool.
+keywords:
+  - logical volume
+  - LVM
+  - Linux logical volume manager
+  - LVM Kubernetes
+  - volume group
 ---
 
 # What is Logical Volume?

--- a/public/glossary/multi-tenant-kubernetes-storage.md
+++ b/public/glossary/multi-tenant-kubernetes-storage.md
@@ -1,6 +1,12 @@
 ---
 title: What is Multi-tenant Kubernetes Storage
 description: Multi-tenant Kubernetes Storage is designed to keep each tenant’s data isolated while sharing infrastructure in a single cluster.
+keywords:
+  - multi-tenant Kubernetes storage
+  - Kubernetes storage isolation
+  - namespace storage Kubernetes
+  - tenant storage isolation
+  - Kubernetes multi-tenancy
 ---
 # What is Multi-tenant Kubernetes Storage?
 

--- a/public/glossary/nfs-share.md
+++ b/public/glossary/nfs-share.md
@@ -1,6 +1,12 @@
 ---
 title: What is NFS Share
 description: An NFS Share lets multiple systems access the same file directory over a network using the Network File System protocol.
+keywords:
+  - NFS share
+  - NFS Kubernetes
+  - network file system
+  - NFS volume
+  - shared storage NFS
 ---
 # What is NFS Share?
 

--- a/public/glossary/nvme-over-fabrics.md
+++ b/public/glossary/nvme-over-fabrics.md
@@ -1,6 +1,12 @@
 ---
 title: What is NVMe over Fabrics
 description: Learn how NVMe over Fabrics improves storage speed and flexibility using protocols like RDMA or TCP across networked devices.
+keywords:
+  - NVMe over Fabrics
+  - NVMe-oF
+  - NVMe fabric storage
+  - high performance storage network
+  - RDMA storage
 ---
 # What is NVMe over Fabrics?
 

--- a/public/glossary/nvme-over-roce.md
+++ b/public/glossary/nvme-over-roce.md
@@ -1,6 +1,12 @@
 ---
 title: What is NVMe over RoCE
 description: NVMe over RoCE is ideal for data-heavy applications that require consistent, high throughput and near-local latency.
+keywords:
+  - NVMe over RoCE
+  - RoCE storage
+  - RDMA over Converged Ethernet
+  - NVMe-oF RoCE
+  - high performance block storage
 ---
 # What is NVMe over RoCE?
 

--- a/public/glossary/nvme-tcp.md
+++ b/public/glossary/nvme-tcp.md
@@ -1,6 +1,12 @@
 ---
 title: What is NVMe over TCP
 description: NVMe over TCP uses standard Ethernet to deliver NVMe storage performance across networks without requiring special hardware.
+keywords:
+  - NVMe over TCP
+  - NVMe-TCP
+  - NVMe storage protocol
+  - high performance TCP storage
+  - NVMe networking
 ---
 # What is NVMe over TCP?
 

--- a/public/glossary/overprovisioning.md
+++ b/public/glossary/overprovisioning.md
@@ -1,6 +1,12 @@
 ---
 title: What is Overprovisioning
 description: Overprovisioning improves IOPS and reduces latency by giving SSD controllers space to manage background operations.
+keywords:
+  - overprovisioning storage
+  - SSD overprovisioning
+  - storage IOPS optimization
+  - NVMe overprovisioning
+  - disk performance tuning
 ---
 # What is Overprovisioning?
 

--- a/public/glossary/persistent-volume-claim.md
+++ b/public/glossary/persistent-volume-claim.md
@@ -1,6 +1,12 @@
 ---
 title: What is Persistent Volume Claim
 description: Persistent Volume Claim allows pods to request storage with specific size and access modes from available volume pools.
+keywords:
+  - PersistentVolumeClaim
+  - PVC Kubernetes
+  - Kubernetes storage request
+  - persistent volume claim
+  - Kubernetes volume binding
 ---
 # What is Persistent Volume Claim?
 

--- a/public/glossary/persistent-volume.md
+++ b/public/glossary/persistent-volume.md
@@ -1,6 +1,12 @@
 ---
 title: What is Persistent Volume
 description: Persistent Volume simplifies storage management in Kubernetes by providing an abstraction over physical or cloud disks.
+keywords:
+  - PersistentVolume
+  - PV Kubernetes
+  - Kubernetes persistent storage
+  - Kubernetes volume abstraction
+  - PV PVC Kubernetes
 ---
 # What is Persistent Volume?
 

--- a/public/glossary/rados-block-device.md
+++ b/public/glossary/rados-block-device.md
@@ -1,6 +1,12 @@
 ---
 title: What is Rados Block Device (RBD)
 description: RADOS Block Device (RBD) is a Ceph storage feature that provides block-level access to distributed storage clusters.
+keywords:
+  - RADOS block device
+  - RBD
+  - Ceph RBD
+  - Ceph block storage
+  - Kubernetes Ceph storage
 ---
 # What is Rados Block Device (RBD)?
 

--- a/public/glossary/readonlymany-in-kubernetes.md
+++ b/public/glossary/readonlymany-in-kubernetes.md
@@ -1,6 +1,12 @@
 ---
 title: What is ReadOnlyMany in Kubernetes
 description: ReadOnlyMany in Kubernetes is commonly used with NFS volumes to distribute data like binaries or config maps across multiple read-only pods.
+keywords:
+  - ReadOnlyMany Kubernetes
+  - ROX access mode
+  - Kubernetes volume access mode
+  - read-only volume Kubernetes
+  - NFS read-only
 ---
 # What is ReadOnlyMany in Kubernetes?
 

--- a/public/glossary/readwritemany-in-kubernetes.md
+++ b/public/glossary/readwritemany-in-kubernetes.md
@@ -1,6 +1,12 @@
 ---
 title: What is ReadWriteMany in Kubernetes
 description: ReadWriteMany in Kubernetes supports concurrent access by many pods to one volume, simplifying shared storage management in clusters.
+keywords:
+  - ReadWriteMany Kubernetes
+  - RWX access mode
+  - Kubernetes shared volume
+  - multi-pod volume access
+  - NFS ReadWriteMany
 ---
 # What is ReadWriteMany in Kubernetes?
 

--- a/public/glossary/readwriteonce-in-kubernetes.md
+++ b/public/glossary/readwriteonce-in-kubernetes.md
@@ -1,6 +1,12 @@
 ---
 title: What is ReadWriteOnce in Kubernetes
 description: ReadWriteOnce in Kubernetes supports controlled volume access, often used for monolithic apps or single-instance database containers.
+keywords:
+  - ReadWriteOnce Kubernetes
+  - RWO access mode
+  - Kubernetes volume access mode
+  - single node volume
+  - PVC access mode
 ---
 # What is ReadWriteOnce in Kubernetes?
 

--- a/public/glossary/readwriteoncepod-in-kubernetes.md
+++ b/public/glossary/readwriteoncepod-in-kubernetes.md
@@ -1,6 +1,12 @@
 ---
 title: What is ReadWriteOncePod in Kubernetes
 description: ReadWriteOncePod in Kubernetes is ideal for cases that require strict volume control and exclusive access on a per-pod basis.
+keywords:
+  - ReadWriteOncePod Kubernetes
+  - RWOP access mode
+  - exclusive pod volume
+  - Kubernetes pod storage isolation
+  - PVC single pod access
 ---
 # What is ReadWriteOncePod in Kubernetes?
 

--- a/public/glossary/static-provisioning-in-kubernetes.md
+++ b/public/glossary/static-provisioning-in-kubernetes.md
@@ -1,6 +1,12 @@
 ---
 title: What is Static Provisioning in Kubernetes
 description: Static Provisioning in Kubernetes is suitable for storage environments where dynamic provisioning is unsupported or unnecessary.
+keywords:
+  - static provisioning Kubernetes
+  - pre-provisioned volume
+  - Kubernetes manual provisioning
+  - PersistentVolume static
+  - Kubernetes storage provisioning
 ---
 # What is Static Provisioning in Kubernetes?
 

--- a/public/glossary/storage-class.md
+++ b/public/glossary/storage-class.md
@@ -1,6 +1,12 @@
 ---
 title: What is a Storage Class
 description: Storage Class allows you to control volume features in Kubernetes, including access modes, performance tiers, and provisioning rules.
+keywords:
+  - StorageClass Kubernetes
+  - Kubernetes storage class
+  - dynamic provisioning StorageClass
+  - CSI StorageClass
+  - Kubernetes provisioner
 ---
 # What is a Storage Class?
 

--- a/public/glossary/storage-in-kubernetes.md
+++ b/public/glossary/storage-in-kubernetes.md
@@ -1,6 +1,12 @@
 ---
 title: What is Storage in Kubernetes
 description: Storage in Kubernetes enables reliable access to external or internal volumes through persistent, ephemeral, or shared mounts.
+keywords:
+  - storage in Kubernetes
+  - Kubernetes volumes overview
+  - Kubernetes storage concepts
+  - persistent ephemeral storage
+  - Kubernetes data management
 ---
 # What is Storage in Kubernetes?
 

--- a/public/glossary/storage-quality-of-services.md
+++ b/public/glossary/storage-quality-of-services.md
@@ -1,6 +1,12 @@
 ---
 title: What is Storage Quality of Services
 description: Storage Quality of Services enables administrators to control latency, throughput, and IOPS for persistent volume access.
+keywords:
+  - storage QoS
+  - Kubernetes storage quality of service
+  - IOPS limits Kubernetes
+  - throughput limits storage
+  - storage performance Kubernetes
 ---
 # What is Storage Quality of Services?
 

--- a/public/glossary/storage-virtualization.md
+++ b/public/glossary/storage-virtualization.md
@@ -1,6 +1,12 @@
 ---
 title: What is Storage Virtualization
 description: Storage Virtualization increases agility by allowing flexible expansion, migration, and load balancing of storage resources.
+keywords:
+  - storage virtualization
+  - virtual storage Kubernetes
+  - software-defined storage
+  - storage abstraction
+  - storage pooling
 ---
 # What is Storage Virtualization?
 

--- a/public/glossary/thin-provisioning.md
+++ b/public/glossary/thin-provisioning.md
@@ -1,6 +1,12 @@
 ---
 title: What is Thin Provisioning
 description: Thin Provisioning is widely used in virtualized and containerized environments to optimize storage infrastructure and reduce waste.
+keywords:
+  - thin provisioning
+  - Kubernetes thin provisioning
+  - storage thin provision
+  - overcommit storage
+  - dynamic storage allocation
 ---
 # What is Thin Provisioning?
 

--- a/public/glossary/volume-health-monitoring.md
+++ b/public/glossary/volume-health-monitoring.md
@@ -1,6 +1,12 @@
 ---
 title: What is Volume Health Monitoring
 description: Volume Health Monitoring supports event-based notifications in Kubernetes, allowing proactive response to storage failures.
+keywords:
+  - Kubernetes volume health monitoring
+  - CSI health monitor
+  - volume health check
+  - storage failure detection
+  - Kubernetes storage events
 ---
 
 # What is Volume Health Monitoring?

--- a/public/glossary/xfs.md
+++ b/public/glossary/xfs.md
@@ -1,6 +1,12 @@
 ---
 title: What is XFS
 description: XFS is widely used in enterprise environments for workloads that demand fast access, reliability, and large volume support.
+keywords:
+  - XFS file system
+  - XFS Kubernetes
+  - Linux XFS
+  - high performance file system
+  - enterprise Linux filesystem
 ---
 # What is XFS?
 

--- a/sitemap-builder.js
+++ b/sitemap-builder.js
@@ -43,7 +43,7 @@ function getDynamicPages(basePath) {
 
 const pages = [...staticPages, ...getDynamicPages("public/glossary")];
 
-let sitemap = "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n";
+let sitemap = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n";
 for (let item of pages) {
   const timestamp = getGitTimestamp(item.source);
   sitemap += `<url>\n<loc>https://storageclass.info${item.path}</loc>\n<lastmod>${timestamp}</lastmod>\n</url>\n`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import StorageClassPage from './pages/StorageClassPage';
 import SponsorsPage from './pages/SponsorsPage';
 import GlossaryIndexPage from "./pages/GlossaryIndexPage.tsx";
 import GlossaryContentPage from "./pages/GlossaryContentPage.tsx";
+import NotFoundPage from "./pages/NotFoundPage.tsx";
 
 function App() {
     const [isDarkMode] = React.useState(() => {
@@ -31,6 +32,7 @@ function App() {
                             <Route path="/glossary" element={<GlossaryIndexPage/>}/>
                             <Route path="/glossary/:file" element={<GlossaryContentPage/>}/>
                             <Route path="/sponsors" element={<SponsorsPage/>}/>
+                            <Route path="*" element={<NotFoundPage/>}/>
                         </Routes>
                     </main>
 

--- a/src/pages/GlossaryIndexPage.tsx
+++ b/src/pages/GlossaryIndexPage.tsx
@@ -35,7 +35,7 @@ const GlossaryIndexPage: React.FC = () => {
             </h1>
             <div className="prose dark:prose-invert max-w-none">
                 <div className="bg-white dark:bg-gray-800 rounded-lg p-6 mb-8">
-                    <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">Topics</h3>
+                    <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">Topics</h2>
                     <p className="text-gray-600 dark:text-gray-300 mb-4">
                         Find all topics around the Kubernetes Container Storage Interface (CSI) in the glossary.
                     </p>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
-import {HardDrive, Database, Users, ExternalLink} from 'lucide-react';
+import {HardDrive, Database, Users, ExternalLink, BookOpen} from 'lucide-react';
 import {setPageMetadata} from "../utils/metadataUtils.js";
 
 const HomePage: React.FC = () => {
@@ -49,7 +49,7 @@ const HomePage: React.FC = () => {
                             StorageClass Basics
                         </Link>
                     </div>
-                    <div className="mt-8 grid grid-cols-2 gap-4 text-sm text-gray-600 dark:text-gray-300">
+                    <div className="mt-8 grid grid-cols-3 gap-4 text-sm text-gray-600 dark:text-gray-300">
                         <div className="rounded-lg border border-gray-200 bg-white/70 p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900/60">
                             <div className="text-2xl font-semibold text-gray-900 dark:text-white">150+</div>
                             Drivers indexed
@@ -57,6 +57,10 @@ const HomePage: React.FC = () => {
                         <div className="rounded-lg border border-gray-200 bg-white/70 p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900/60">
                             <div className="text-2xl font-semibold text-gray-900 dark:text-white">10+</div>
                             Capability filters
+                        </div>
+                        <div className="rounded-lg border border-gray-200 bg-white/70 p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900/60">
+                            <div className="text-2xl font-semibold text-gray-900 dark:text-white">50+</div>
+                            Glossary articles
                         </div>
                     </div>
                 </div>
@@ -93,8 +97,14 @@ const HomePage: React.FC = () => {
                 </div>
             </div>
 
-            <div className="grid md:grid-cols-3 gap-6 mb-16">
+            <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6 mb-16">
                 {[
+                    {
+                        icon: <HardDrive className="w-10 h-10 text-blue-600 dark:text-blue-400" />,
+                        title: "CSI Drivers Directory",
+                        description: "Compare CSI drivers across features, vendors, and Kubernetes versions.",
+                        link: "/drivers",
+                    },
                     {
                         icon: <Database className="w-10 h-10 text-blue-600 dark:text-blue-400" />,
                         title: "StorageClass Explained",
@@ -102,10 +112,10 @@ const HomePage: React.FC = () => {
                         link: "/storage-class",
                     },
                     {
-                        icon: <HardDrive className="w-10 h-10 text-blue-600 dark:text-blue-400" />,
-                        title: "CSI Drivers Directory",
-                        description: "Compare CSI drivers across features, vendors, and Kubernetes versions.",
-                        link: "/drivers",
+                        icon: <BookOpen className="w-10 h-10 text-blue-600 dark:text-blue-400" />,
+                        title: "Glossary",
+                        description: "Definitions for Kubernetes storage and CSI concepts, from PVC to NVMe-oF.",
+                        link: "/glossary",
                     },
                     {
                         icon: <Users className="w-10 h-10 text-blue-600 dark:text-blue-400" />,
@@ -134,22 +144,28 @@ const HomePage: React.FC = () => {
             </div>
 
             <div className="grid md:grid-cols-2 gap-6">
-                <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+                <Link to="/drivers" className="group rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:border-blue-300 hover:shadow-lg dark:border-gray-800 dark:bg-gray-900">
                     <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2">
                         For Developers
                     </h3>
-                    <p className="text-gray-600 dark:text-gray-300">
+                    <p className="text-gray-600 dark:text-gray-300 mb-3">
                         Pinpoint CSI drivers for specific stacks, validate compatibility, and ship faster.
                     </p>
-                </div>
-                <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+                    <span className="text-sm font-semibold text-blue-700 group-hover:text-blue-800 dark:text-blue-300 dark:group-hover:text-blue-200">
+                        Browse drivers →
+                    </span>
+                </Link>
+                <Link to="/glossary" className="group rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:border-blue-300 hover:shadow-lg dark:border-gray-800 dark:bg-gray-900">
                     <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2">
                         For Operations
                     </h3>
-                    <p className="text-gray-600 dark:text-gray-300">
+                    <p className="text-gray-600 dark:text-gray-300 mb-3">
                         Compare lifecycle support, access modes, and advanced capabilities before you deploy.
                     </p>
-                </div>
+                    <span className="text-sm font-semibold text-blue-700 group-hover:text-blue-800 dark:text-blue-300 dark:group-hover:text-blue-200">
+                        Explore glossary →
+                    </span>
+                </Link>
             </div>
 
             <div className="mt-16 rounded-2xl border border-blue-100 bg-blue-50 p-8 text-center shadow-sm dark:border-blue-900/40 dark:bg-blue-950/40">

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {Link} from 'react-router-dom';
+import {setPageMetadata} from "../utils/metadataUtils.js";
+
+const NotFoundPage: React.FC = () => {
+    setPageMetadata({
+        title: "Page Not Found | StorageClass.info",
+        description: "The page you were looking for could not be found.",
+    });
+
+    return (
+        <div className="max-w-2xl mx-auto text-center py-24">
+            <div className="text-6xl font-bold text-blue-600 dark:text-blue-400 mb-4">404</div>
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white mb-3">
+                Page not found
+            </h1>
+            <p className="text-gray-600 dark:text-gray-300 mb-8">
+                The page you were looking for doesn't exist or has been moved.
+            </p>
+            <div className="flex flex-wrap justify-center gap-4">
+                <Link
+                    to="/"
+                    className="inline-flex items-center justify-center rounded-xl bg-blue-600 px-6 py-3 text-base font-semibold text-white shadow-lg shadow-blue-600/30 transition hover:-translate-y-0.5 hover:bg-blue-700"
+                >
+                    Go home
+                </Link>
+                <Link
+                    to="/drivers"
+                    className="inline-flex items-center justify-center rounded-xl border border-gray-200 bg-white px-6 py-3 text-base font-semibold text-gray-800 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-300 hover:text-blue-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:border-blue-500"
+                >
+                    Browse CSI Drivers
+                </Link>
+            </div>
+        </div>
+    );
+};
+
+export default NotFoundPage;

--- a/src/pages/SponsorsPage.tsx
+++ b/src/pages/SponsorsPage.tsx
@@ -4,7 +4,8 @@ import {setPageMetadata} from "../utils/metadataUtils.js";
 const SponsorsPage: React.FC = () => {
     setPageMetadata({
         title: "Storageclass.info Sponsors",
-        description: "Thank you to Simplyblock for sponsoring the domain and webspace for storageclass.info."
+        description: "Thank you to Simplyblock for sponsoring the domain and webspace for storageclass.info.",
+        keywords: ["StorageClass.info sponsors", "Simplyblock", "Kubernetes storage sponsor"],
     })
 
     return (

--- a/src/pages/StorageClassPage.tsx
+++ b/src/pages/StorageClassPage.tsx
@@ -6,6 +6,7 @@ const StorageClassPage: React.FC = () => {
     setPageMetadata({
         title: "StorageClass Specification",
         description: "StorageClass defines classes of storage in Kubernetes. Covers dynamic provisioning, provisioner field, volume policies, and configuration options.",
+        keywords: ["StorageClass", "Kubernetes storage class", "dynamic provisioning", "Kubernetes storage", "CSI provisioner", "persistent volume"],
     });
 
     return (

--- a/src/utils/metadataUtils.ts
+++ b/src/utils/metadataUtils.ts
@@ -54,7 +54,7 @@ export function setPageMetadata(metadata: PageMetadata) {
         setMetaTag("name", "keywords", metadata.keywords.join(", "));
     }
 
-    const canonicalUrl = metadata.canonicalUrl ?? window.location.href;
+    const canonicalUrl = metadata.canonicalUrl ?? (window.location.origin + window.location.pathname);
     setCanonicalTag(canonicalUrl);
     setMetaTag("property", "og:url", canonicalUrl);
 


### PR DESCRIPTION
- Fix sitemap lastmod: add fetch-depth: 0 to CI checkout so git log returns timestamps for all files, not just the latest commit
- Fix canonical URLs: strip query params (use origin+pathname, not href) to prevent duplicate content signals on filtered pages
- Fix .htaccess RewriteBase /subdirectory -> / for correct SPA routing
- Add XML declaration to sitemap-builder.js output
- Add 404 NotFoundPage with catch-all route in App.tsx
- Add keywords to StorageClassPage, SponsorsPage, and all 49 glossary markdown files (previously 0 had keywords in front matter)
- Fix H1->H3 heading jump in GlossaryIndexPage (now H1->H2)
- Homepage: add Glossary as 4th nav card, add 50+ articles stat, convert For Developers/Operations boxes into clickable cards with CTAs